### PR TITLE
Fix block-comment

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -3,7 +3,7 @@
         // symbol used for single line comment. Remove this entry if your language does not support line comments
         "lineComment": "--",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "{*", "*}" ]
+        "blockComment": [ "{-", "-}" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
> https://github.com/dhall-lang/dhall-lang/blob/master/standard/dhall.abnf#L152-L163

Just noticed that it put wrong block comment when `CTRL + SHIFT + A`
![Peek 2019-09-11 11-31](https://user-images.githubusercontent.com/4953069/64668419-b7277280-d487-11e9-9205-a145752b1b3c.gif)

