### PR TITLE
Set file icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
                 "extensions": [
                     "dhall"
                 ],
+                "icon": {
+                    "dark": "images/dhall-icon.png",
+                    "light": "images/dhall-icon.png"
+                },
                 "configuration": "./language-configuration.json"
             }
         ],


### PR DESCRIPTION
See for example https://github.com/nix-community/vscode-nix-ide/pull/313.

This is a proof-of-concept since I got all sorts of errors from running `npm install`, and have thus been unable to build. We should probably modify the colours for dark mode.